### PR TITLE
fix: old timetables API url has been shut down

### DIFF
--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -104,15 +104,13 @@ image::{gitplant}/technical-context.puml[Technical Context Diagram]
 
 ===== Deutsche Bahn Germany Open API Portal
 
-Section <<Subscribe to the Deutsche Bahn Open Data Timetables v1 API>> describes how to register for the API and subscribe to the used services.
+Section <<Subscribe to the DB API Marketplace Timetables API>> describes how to register for the API and subscribe to the used services.
 
 The following links give detailed information on the API:
 
-* https://developer.deutschebahn.com/store/site/pages/home.jag[Open API-Portal] of Deutsche
-Bahn, Germany
+* https://developers.deutschebahn.com/db-api-marketplace/apis/[DB API Marketplace] of Deutsche Bahn, Germany
 
-* https://developer.deutschebahn.com/store/apis/info?name=Timetables&version=v1&provider=DBOpenData[Timetables -
-v1 API]
+* https://developers.deutschebahn.com/db-api-marketplace/apis/product/timetables/api/1309#/Timetables_10197/overview[Timetables API]
 
 == 4 Solution Strategy
 
@@ -223,21 +221,19 @@ This section lists the steps to set up a deployment to https://cloud.google.com/
 
 ==== 7.2.1 Prerequisites
 
-===== Subscribe to the Deutsche Bahn Open Data Timetables v1 API
+===== Subscribe to the DB API Marketplace Timetables API
 
-The `train-delays` web application requires an access key for the Deutsche Bahn Open API-Portal. You can get one for
+The `train-delays` web application requires an access key for the DB API Marketplace. You can get one for
 free:
 
-. Register a free account for https://developer.deutschebahn.com/store/site/pages/home.jag[Open API-Portal] of Deutsche
-Bahn, Germany.
+. Follow the instructions in https://developers.deutschebahn.com/db-api-marketplace/apis/start[So startest Du einfach mit den APIs
+] (in German)
 
-. On the https://developer.deutschebahn.com/store/site/pages/subscriptions.jag[My Subscriptions Tab] generate a key for
-the production environment.
+. From the https://developers.deutschebahn.com/db-api-marketplace/apis/product[Catalog of the DB API Marketplace] subscribe to the **Timetables** API
 
-. On the https://developer.deutschebahn.com/store/apis/info?name=Timetables&version=v1&provider=DBOpenData[Timetables -
-v1 API page]
-  * Select `DefaultApplication` in the `Application` dropdown
-  * Click `Subscribe`
+Attention:
+
+Store the API Key for APIs you subscribe to a password safe. The DB API Marketplace will not show the key later, but you can verify whether you have stored the correct key in the https://developers.deutschebahn.com/db-api-marketplace/apis/application[DB API Marketplace Applications tab].
 
 ===== Register with Google Cloud Platform and Install the gcloud CLI
 
@@ -298,7 +294,7 @@ The following articles describe the used concepts:
 
 This application uses https://pact.io/[Pact] tests to verify the following APIs:
 
-* Consuming the https://developer.deutschebahn.com/store/apis/info?name=Timetables&version=v1&provider=DBOpenData[Deutsche Bahn Timetables v1 API]
+* Consuming the https://developers.deutschebahn.com/db-api-marketplace/apis/product/timetables/api/1309#/Timetables_10197/overview[Deutsche Bahn Timetables API]
 * Providing the TrainDelays API
 
 ==== 8.2.3 Web Application UI Tests

--- a/docs/timetables.http
+++ b/docs/timetables.http
@@ -1,11 +1,13 @@
 # This file contains HTTP requests for the DB Open Data Timetables API
 
 ### Query all known changes for the station eva id
-GET https://api.deutschebahn.com/timetables/v1/fchg/8005143
-Authorization: Bearer {{auth_token}}
+GET https://apis.deutschebahn.com/db-api-marketplace/apis/timetables/v1/fchg/8005143
 Accept: application/xml
+DB-Client-Id: {{client_id}}
+DB-Api-Key: {{api_key}}
 
 ### Query station eva id for Rösrath-Stümpen
-GET https://api.deutschebahn.com/timetables/v1/station/r%C3%B6srath-st%C3%BCmpen
-Authorization: Bearer {{auth_token}}
+GET https://apis.deutschebahn.com/db-api-marketplace/apis/timetables/v1/station/r%C3%B6srath-st%C3%BCmpen
 Accept: application/xml
+DB-Client-Id: {{client_id}}
+DB-Api-Key: {{api_key}}

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -8,19 +8,23 @@
 
 ### Prerequisite
 
-Please register with and subscribe to the [Timetables - v1
-API](https://developer.deutschebahn.com/store/apis/info?name=Timetables&version=v1&provider=DBOpenData). This is described in detail in section [7.2.1 Prerequisites of the Architecture Document](architecture.adoc#721-prerequisites).
+Please register with and subscribe to the [Timetables
+API](https://developers.deutschebahn.com/db-api-marketplace/apis/product/timetables/api/1309#/Timetables_10197/overview).
+This is described in detail in section [7.2.1 Prerequisites of the Architecture
+Document](architecture.adoc#721-prerequisites).
 
 ### Run the Application in a Docker Container
 
 The [build pipeline](../.github/workflows/build.yml) publishes the application to [Docker
 Hub](https://hub.docker.com/r/boos/train-delays). Thus, you can pull an image and run it.
 
-Then, in the following, replace `<YOUR API KEY>` with the `Access Token` displayed on the [My Subscriptions
-Tab](https://developer.deutschebahn.com/store/site/pages/subscriptions.jag).
+Then, in the following, replace `<YOUR CLIENT ID>` and `<YOUR API KEY>` with the values displayed in the section "Berechtigungsnachweise" for your application in [DB API Marketplace / Anwendungen](https://developers.deutschebahn.com/db-api-marketplace/apis/application).
+
+Note: The API Key will not be revealed. Please save the key to a password safe when creating it (see [7.2.1 Prerequisites of the Architecture
+Document](architecture.adoc#721-prerequisites)).
 
 ```sh
-docker run -p 8080:8080 --env API_KEY=<YOUR API KEY> --name train-delays-app --rm boos/train-delays
+docker run -p 8080:8080 --env CLIENT_ID=<YOUR CLIENT ID> --env API_KEY=<YOUR API KEY> --name train-delays-app --rm boos/train-delays
 ```
 
 ### Run the Application Using a Local Java Installation

--- a/src/main/java/systems/boos/traindelays/TimetablesService.java
+++ b/src/main/java/systems/boos/traindelays/TimetablesService.java
@@ -41,11 +41,8 @@ public class TimetablesService {
 
     private HttpEntity<String> getRequestEntity() {
         HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.AUTHORIZATION, generateAuthToken());
+        headers.add("DB-Client-Id", System.getenv("CLIENT_ID"));
+        headers.add("DB-Api-Key", System.getenv("API_KEY"));
         return new HttpEntity<>(headers);
-    }
-
-    private String generateAuthToken() {
-        return "Bearer " + System.getenv("API_KEY");
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-provider.baseUrl=https://api.deutschebahn.com/timetables/v1
+provider.baseUrl=https://apis.deutschebahn.com/db-api-marketplace/apis/timetables/v1


### PR DESCRIPTION
After the Deutsche Bahn transitioned from "Deutsche Bahn Open Data" portal to "DB API Marketplace" (without further notice), the application was broken.

The root causes were:

- Authentication Headers used for all HTTP Requests have changed
- Base URL of the Timetables API has changed