### PR TITLE
fix(deps): build works for main branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     testImplementation 'net.sourceforge.htmlunit:htmlunit:2.67.0'
 
     testImplementation 'au.com.dius.pact.consumer:java8:4.1.39'
-    testImplementation 'au.com.dius.pact.consumer:junit5:4.5.1'
+    testImplementation 'au.com.dius.pact.consumer:junit5:4.3.14'
     testImplementation 'au.com.dius.pact.provider:junit5spring:4.3.15'
 
     testImplementation 'org.json:json:20220924'


### PR DESCRIPTION
Upgrading the Pact Consumer library from 4.3.14 to 4.5.1 broke the build on main.

This revert commit shall fix the build on main until the problem is solved on a separate branch.
